### PR TITLE
Add "server.network" method

### DIFF
--- a/src/server_processor.py
+++ b/src/server_processor.py
@@ -93,6 +93,9 @@ class ServerProcessor(Processor):
         elif method == 'server.version':
             result = VERSION
 
+        elif method == 'server.network':
+            result = self.config.get('network', 'type')
+
         else:
             raise BaseException("unknown method: %s"%repr(method))
 


### PR DESCRIPTION
`server.network` is used in [testnet support](https://github.com/Kefkius/electrum-dash/commit/1667914fea4ff7866695751e5e53b1f03e342f42) to determine if a server is compatible with a client.